### PR TITLE
Adding WPA2 support

### DIFF
--- a/docker-init.sh
+++ b/docker-init.sh
@@ -109,6 +109,7 @@ fi
 : ${RRM_BEACON_REPORT:=1}
 : ${WPA_DISABLE_EAPOL_KEY_RETRIES:=1}
 : ${WPA_KEY_MGMT:=WPA-EAP WPA-EAP-SHA256}
+: ${WPA_PASSPHRASE:=0}
 : ${OKC:=0}
 : ${DISABLE_PMKSA_CACHING:=1}
 : ${IEEE80211W:=1}
@@ -212,6 +213,7 @@ ieee8021x=${IEEE8021X}
 auth_algs=${AUTH_ALGS}
 wpa=${WPA}
 wpa_pairwise=${WPA_PAIRWISE}
+wpa_passphrase=${WPA_PASSPHRASE}
 ssid=${SSID}
 
 ${BRIDGE+"bridge=${BRIDGE}"}

--- a/hostapd-build.conf
+++ b/hostapd-build.conf
@@ -50,6 +50,8 @@ CONFIG_RSN_PREAUTH=y
 # Support Operating Channel Validation
 #CONFIG_OCV=y
 
+CONFIG_WPA_PASSPHRASE=y
+
 # Integrated EAP server
 CONFIG_EAP=y
 


### PR DESCRIPTION
Hi,

I tried using this docker image to run a WiFi AP using WPA2 and had trouble getting it to work.

It looks like the WPA passphrase parameter does not get set in the hostapd.conf file. It should contain "wpa_passphrase" as a variable. The other required config parameters are set correctly, so I added it to the list. 

I build the docker image locally and can confirm it's working. I haven't tested whether this might interfer with a radius setup, but I'd assume wpa_passphrase is just ignored when a different authentication method is configured.

Also, thanks for your work on this!